### PR TITLE
Fixing a bug for cocoapods v0.39.0

### DIFF
--- a/Source/NBULog.m
+++ b/Source/NBULog.m
@@ -24,7 +24,7 @@
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
-#if __has_include(<LumberjackConsole/PTEDashboard.h>)
+#ifdef DEBUG
     #import <LumberjackConsole/PTEDashboard.h>
 #endif
 
@@ -121,7 +121,7 @@ static id<DDLogFormatter> _nbuLogFormatter;
 
 + (void)addDashboardLogger
 {
-#if __has_include(<LumberjackConsole/PTEDashboard.h>)
+#ifdef DEBUG
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^
                   {

--- a/Source/NBULog.m
+++ b/Source/NBULog.m
@@ -24,7 +24,7 @@
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
-#ifdef DEBUG
+#if __has_include("PTEDashboard")
     #import <LumberjackConsole/PTEDashboard.h>
 #endif
 
@@ -121,7 +121,7 @@ static id<DDLogFormatter> _nbuLogFormatter;
 
 + (void)addDashboardLogger
 {
-#ifdef DEBUG
+#if __has_include("PTEDashboard")
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^
                   {

--- a/Source/NBULog.m
+++ b/Source/NBULog.m
@@ -24,7 +24,7 @@
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
-#if defined(SHOW_DASHBOARD)
+#if defined(NBU_SHOW_DASHBOARD)
     #import <LumberjackConsole/PTEDashboard.h>
 #endif
 
@@ -121,7 +121,7 @@ static id<DDLogFormatter> _nbuLogFormatter;
 
 + (void)addDashboardLogger
 {
-#if defined(SHOW_DASHBOARD)
+#if defined(NBU_SHOW_DASHBOARD)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^
                   {

--- a/Source/NBULog.m
+++ b/Source/NBULog.m
@@ -24,7 +24,7 @@
 #import <CocoaLumberjack/DDTTYLogger.h>
 #import <CocoaLumberjack/DDFileLogger.h>
 #import <CocoaLumberjack/DDASLLogger.h>
-#if __has_include("PTEDashboard")
+#if defined(SHOW_DASHBOARD)
     #import <LumberjackConsole/PTEDashboard.h>
 #endif
 
@@ -121,7 +121,7 @@ static id<DDLogFormatter> _nbuLogFormatter;
 
 + (void)addDashboardLogger
 {
-#if __has_include("PTEDashboard")
+#if defined(SHOW_DASHBOARD)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^
                   {


### PR DESCRIPTION
This macro "__has_include(<LumberjackConsole/PTEDashboard.h>)" doesn't work after cocoapods version 0.39.0. If people don't wanna use or show the dashboard, it will be crash. One of the way to fix it is replacing the "#import <LumberjackConsole/PTEDashboard.h>" to defined(NBU_SHOW_DASHBOARD), which is the same effect as the macro "AF_APP_EXTENSIONS" in AFNetworking. While people wanna use or show the dashboard, just add a macro definition, NBU_SHOW_DASHBOARD=1, to make it works.
